### PR TITLE
Improve reactive values

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ class MyDialog {
         m_slider = new Slider;
 
         m_label = new Label;
-        m_label.caption = m_slider.value.map!(n => n.to!string);
+        m_label.caption = m_slider.value.mapValue!(n => n.to!string);
     }
 }
 ```

--- a/source/observable/observable.d
+++ b/source/observable/observable.d
@@ -14,6 +14,7 @@ import observable.signal : Signal, SignalConnection;
 
 import core.time : Duration;
 import std.meta : allSatisfy, staticMap;
+import std.traits : isCopyable;
 import std.typecons : RefCounted, RefCountedAutoInitialize, refCounted;
 import taggedalgebraic.taggedunion;
 import vibe.core.log : logException;
@@ -458,7 +459,7 @@ class ObserverClosedException : Exception {
 	The return value is an observer that emits the transformed events.
 */
 auto map(alias fun, O)(O source)
-	if (isObservable!O)
+	if (isObservable!O && isCopyable!O)
 {
 	alias T = ObservableType!O;
 	alias TM = typeof(fun(T.init));


### PR DESCRIPTION
- Renames map to mapValue to avoid conflicts with observable.observable.map (let's pretend this has always been the name)
- Generalizes mapValue to multiple input values
- Adds ValueType!V to extract the contained value type of a reactive value
- Fixes premature disconnects of bound reactive values