### PR TITLE
Use vibe.container.internal.utilallocator

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -7,3 +7,4 @@ authors "Sönke Ludwig"
 targetType "library"
 
 dependency "vibe-core" version=">=1.0.0 <3.0.0-0"
+dependency "vibe-container" version=">=1.0.2 <2.0.0-0"

--- a/source/observable/signal.d
+++ b/source/observable/signal.d
@@ -636,7 +636,7 @@ private class TypedConnectionHead(P...) : ConnectionHead {
 }
 
 private final class CallableConnectionHead(S, C, FP...) : TypedConnectionHead!(S.Params) {
-	import vibe.internal.allocator : Mallocator, make, dispose;
+	import vibe.container.internal.utilallocator : Mallocator, make, dispose;
 	import std.traits : hasIndirections;
 	import core.memory : GC;
 


### PR DESCRIPTION
`vibe.internal.allocator` has been deprecated.