### PR TITLE
Fixes for filter() and RCRef

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.dub
 /observable-test*
+/libobservable.a
+/observable.lib
 dub.selections.json


### PR DESCRIPTION
- Fixes the use of `filter()` predicates that access their surrounding scope
- Fixes an issue with payloads containing GC references in `RCRef`